### PR TITLE
refactored the interface with the DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+config/database.json

--- a/controllers/CRUD-cube.js
+++ b/controllers/CRUD-cube.js
@@ -1,8 +1,5 @@
 const Cube = require('../models/cube');
-const fs = require('fs');
-const path = require('path');
-const databaseFile = path.join(__dirname, '..', 'config/database.json');
-
+const FSpackage = require('./FSpackage');
 
 const createCube = (data) => {
     const { name, description, imageUrl, difficultyLevel } = data;
@@ -11,13 +8,11 @@ const createCube = (data) => {
 };
 
 const getAllCubes = () => {
-        const cubes = fs.readFileSync(databaseFile);
-        return JSON.parse(cubes);
+        return FSpackage.readAll()
 };
 
 const getOne = (id) => {
-    return JSON.parse(fs.readFileSync(databaseFile))
-    .filter(x => x.id === id);  
+    return FSpackage.readOne(id);
 };
 
 module.exports = {

--- a/controllers/FSpackage.js
+++ b/controllers/FSpackage.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const databaseFile = path.join(__dirname, '..', 'config/database.json');
+
+const FSpackage = {
+    write: function (newCube) {
+        fs.readFile(databaseFile, (err, dbData) => {
+            if (err) {
+                throw err;
+            }
+            const cubes = JSON.parse(dbData);
+            cubes.push(newCube);
+
+            fs.writeFile(databaseFile, JSON.stringify(cubes), error => {
+                if (error) {
+                    throw error;
+                };
+                console.log('New Cube is successfully added!');
+            });
+        });
+    },
+    readAll: function () {
+        const cubes = fs.readFileSync(databaseFile);
+        return JSON.parse(cubes);
+    },
+    readOne: function (id) {
+        return JSON.parse(fs.readFileSync(databaseFile))
+            .filter(x => x.id === id);
+    },
+}
+
+module.exports = FSpackage;

--- a/models/cube.js
+++ b/models/cube.js
@@ -1,7 +1,5 @@
 const { v4: uuidv4, v4 } = require('uuid');
-const fs = require('fs');
-const path = require('path');
-const databaseFile = path.join(__dirname, '..', 'config/database.json');
+const FSpackage = require('../controllers/FSpackage');
 
 class Cube {
     constructor(name, description, imageUrl, difficulty){
@@ -11,29 +9,17 @@ class Cube {
         this.imageUrl = imageUrl || 'img';
         this.difficulty = difficulty || 1;
     };
-    save(){
-        const newCube = {
+    get cube(){
+        return {
             id: this.id,
             name: this.name,
             description: this.description,
             imageUrl: this.imageUrl,
             difficulty: this.difficulty,
         };
-
-        fs.readFile(databaseFile, (err, dbData) => {
-            if(err){
-                throw err;
-            }
-            const cubes = JSON.parse(dbData);
-            cubes.push(newCube);
-
-            fs.writeFile(databaseFile, JSON.stringify(cubes), error => {
-                if (error) {
-                    throw error;
-                };
-                console.log('New Cube is successfully added!');
-            });
-        });
+    };
+    save(){
+        FSpackage.write(this.cube);
     };
 };
 


### PR DESCRIPTION
I tried to refactor the code as much as possible. The class Cube and the CRUD-cube looks much cleaner without borrowing with the fs methods. So that I make my own FSpackage which all neccessary operations are being made there and we include ('fs', 'path', 'databasePath') only there. The FS package is the most inner and only one module that contacts directly with the DB.